### PR TITLE
Fix 5.9 and nightly allocation limits (#2485)

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_rst_connections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_rst_connections.swift
@@ -15,6 +15,17 @@
 import NIOCore
 import NIOPosix
 
+private final class CloseAfterTimeoutHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    func channelActive(context: ChannelHandlerContext) {
+        context.fireChannelActive()
+        context.eventLoop.scheduleTask(in: .milliseconds(1)) {
+            context.close(promise: nil)
+        }
+    }
+}
+
 func run(identifier: String) {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer {
@@ -27,6 +38,11 @@ func run(identifier: String) {
     
     let serverAddress = serverConnection.localAddress!
     let clientBootstrap = ClientBootstrap(group: group)
+        .channelInitializer { channel in
+            channel.eventLoop.makeCompletedFuture {
+                try channel.pipeline.syncOperations.addHandler(CloseAfterTimeoutHandler())
+            }
+        }
 
     measure(identifier: identifier, trackFDs: true) {
         let iterations = 1000
@@ -35,7 +51,7 @@ func run(identifier: String) {
             
             let _: Void? = try? conn.flatMap { channel in
                 (channel as! SocketOptionProvider).setSoLinger(linger(l_onoff: 1, l_linger: 0)).flatMap {
-                    channel.close()
+                    channel.closeFuture
                 }
             }.wait()
         }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
@@ -74,6 +74,7 @@ func run(identifier: String) {
             try! el.flatSubmit {
                 clientBootstrap.connect(to: serverAddress).flatMap { (clientChannel) -> EventLoopFuture<Void> in
                     writeWaitAndClose(clientChannel: clientChannel, buffer: buffer)
+                        .flatMap { clientChannel.closeFuture }
                 }
             }.wait()
         }

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=146050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=151050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=156050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -35,13 +35,13 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=400050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=400000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -34,9 +34,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -34,9 +34,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148050
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=150050
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050


### PR DESCRIPTION
# Motivation
Our 5.9 and nightly CI has been failing for some time now due to flaky allocation tests.

# Modification
This PR slightly changes some shared infra for how we ran some of our allocation tests. We are now waiting for the client and server channel to close so that allocations are more stable.

# Results
Green CI again

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
