### PR TITLE
Fix leaked promise in `NIOTypedApplicationProtocolNegotiationHandler`…

### DIFF
--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -80,6 +80,16 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
         }
     }
 
+    deinit {
+        switch self.stateMachine.deinitHandler() {
+        case .failPromise:
+            self.negotiatedPromise.fail(ChannelError.inappropriateOperationForState)
+
+        case .none:
+            break
+        }
+    }
+
     @_spi(AsyncChannel)
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         switch self.stateMachine.userInboundEventTriggered(event: event) {

--- a/Sources/NIOTLS/ProtocolNegotiationHandlerStateMachine.swift
+++ b/Sources/NIOTLS/ProtocolNegotiationHandlerStateMachine.swift
@@ -30,6 +30,27 @@ struct ProtocolNegotiationHandlerStateMachine<NegotiationResult> {
     private var state = State.initial
 
     @usableFromInline
+    enum DeinitHandlerAction {
+        case failPromise
+    }
+
+    @inlinable
+    mutating func deinitHandler() -> DeinitHandlerAction? {
+        switch self.state {
+        case .initial:
+            return .failPromise
+
+        case .waitingForUser, .unbuffering:
+            // We are retaining the handler strongly while waiting and unbuffering
+            // so we should never hit the deinit.
+            fatalError("Unexpected state")
+
+        case .finished:
+            return .none
+        }
+    }
+
+    @usableFromInline
     enum UserInboundEventTriggeredAction {
         case fireUserInboundEventTriggered
         case invokeUserClosure(ALPNResult)


### PR DESCRIPTION
… (#2489)

# Motivation
We sometimes leaked a promise in the `NIOTypedApplicationProtocolNegotiationHandler` when the handler was created and immediately deinited.

# Modification
This PR makes sure we always complete the negotiation promise of the handler.

# Result
No more leaked promises.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
