### PR TITLE
Get Android building again after #2479 (#2490)

### DIFF
--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -15,7 +15,7 @@
 import NIOCore
 #if canImport(Darwin)
 import CNIODarwin
-#elseif os(Linux)
+#elseif os(Linux) || os(Android)
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -168,7 +168,7 @@ extension ChannelOptions.Types {
 extension NIOBSDSocket.AddressFamily {
     /// Address for vsock.
     public static var vsock: NIOBSDSocket.AddressFamily {
-#if canImport(Darwin) || os(Linux)
+#if canImport(Darwin) || os(Linux) || os(Android)
         NIOBSDSocket.AddressFamily(rawValue: AF_VSOCK)
 #else
         fatalError(vsockUnimplemented)
@@ -179,7 +179,7 @@ extension NIOBSDSocket.AddressFamily {
 extension NIOBSDSocket.ProtocolFamily {
     /// Address for vsock.
     public static var vsock: NIOBSDSocket.ProtocolFamily {
-#if canImport(Darwin) || os(Linux)
+#if canImport(Darwin) || os(Linux) || os(Android)
         NIOBSDSocket.ProtocolFamily(rawValue: PF_VSOCK)
 #else
         fatalError(vsockUnimplemented)
@@ -189,7 +189,7 @@ extension NIOBSDSocket.ProtocolFamily {
 
 extension VsockAddress {
     public func withSockAddr<T>(_ body: (UnsafePointer<sockaddr>, Int) throws -> T) rethrows -> T {
-#if canImport(Darwin) || os(Linux)
+#if canImport(Darwin) || os(Linux) || os(Android)
         return try self.address.withSockAddr({ try body($0, $1) })
 #else
         fatalError(vsockUnimplemented)
@@ -199,7 +199,7 @@ extension VsockAddress {
 
 // MARK: - Internal functions that are only available on supported platforms.
 
-#if canImport(Darwin) || os(Linux)
+#if canImport(Darwin) || os(Linux) || os(Android)
 extension VsockAddress.ContextID {
     /// Get the context ID of the local machine.
     ///
@@ -218,7 +218,7 @@ extension VsockAddress.ContextID {
 #if canImport(Darwin)
         let request = CNIODarwin_IOCTL_VM_SOCKETS_GET_LOCAL_CID
         let fd = socketFD
-#elseif os(Linux)
+#elseif os(Linux) || os(Android)
         let request = CNIOLinux_IOCTL_VM_SOCKETS_GET_LOCAL_CID
         let fd = try! Posix.open(file: "/dev/vsock", oFlag: O_RDONLY | O_CLOEXEC)
         defer { try! Posix.close(descriptor: fd) }
@@ -277,4 +277,4 @@ extension BaseSocket {
     }
 }
 
-#endif  // canImport(Darwin) || os(Linux)
+#endif  // canImport(Darwin) || os(Linux) || os(Android)

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -235,7 +235,7 @@ class EchoServerClientTest : XCTestCase {
 
         #if canImport(Darwin)
         let connectAddress = VsockAddress(cid: .any, port: port)
-        #elseif os(Linux)
+        #elseif os(Linux) || os(Android)
         let connectAddress = VsockAddress(cid: .local, port: port)
         #endif
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group).connect(to: connectAddress).wait())

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -28,7 +28,7 @@ extension System {
     }
 
     static var supportsVsock: Bool {
-#if canImport(Darwin) || os(Linux)
+#if canImport(Darwin) || os(Linux) || os(Android)
         guard let socket = try? Socket(protocolFamily: .vsock, type: .stream) else { return false }
         XCTAssertNoThrow(try socket.close())
         return true


### PR DESCRIPTION
Motivation

NIO wasn't building on Android

Modifications

- Add the right checks for Android

Result

Built and passed all tests on Android AArch64

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
