### PR TITLE
AsyncChannel: Provide throwing finish method on test stream (#2493)

### DIFF
--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
@@ -37,4 +37,26 @@ final class AsyncChannelInboundStreamTests: XCTestCase {
             XCTAssertEqual(result, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         }
     }
+
+    func testTestingStream_whenThrowing() async throws {
+        let (stream, source) = NIOAsyncChannelInboundStream<Int>.makeTestingStream()
+
+        await withThrowingTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                var elements = [Int]()
+                for try await element in stream {
+                    elements.append(element)
+                }
+                return elements
+            }
+            source.finish(throwing: ChannelError.alreadyClosed)
+
+            do {
+                _ = try await group.next()
+                XCTFail("Expected an error to be thrown")
+            } catch {
+                XCTAssertEqual(error as? ChannelError, .alreadyClosed)
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Motivation
We recently provided testing utilities for the `NIOAsyncChannelInboundStream`. On thing that was missing is a way to finish the stream with an error.

# Modification
This PR provides a `finish()` method that takes an error which is thrown from the inbound stream.

# Result
Better way to test code relying on the AsyncChannel work.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
